### PR TITLE
Support passing array json body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+alcli/version.py

--- a/alcli/alertlogic_cli.py
+++ b/alcli/alertlogic_cli.py
@@ -26,6 +26,7 @@ from almdrlib.region import Residency
 from almdrlib.version import version as almdrlib_version
 
 from alcli.cliparser import ALCliArgsParser
+from alcli.cliparser import ALCliParserUtils
 from alcli.cliparser import USAGE
 from alcli.clihelp import ALCliMainHelpFormatter
 from alcli.clihelp import ALCliServiceHelpFormatter
@@ -257,8 +258,18 @@ class ServiceOperation(object):
         type = parameter[OpenAPIKeyWord.TYPE]
         if type in OpenAPIKeyWord.SIMPLE_DATA_TYPES:
             return param_value
-        
-        if type == OpenAPIKeyWord.OBJECT:
+
+        if type == OpenAPIKeyWord.ARRAY:
+            items_type = ALCliParserUtils.detect_array_items_type(schema.get('items', {}))
+            if items_type in OpenAPIKeyWord.SIMPLE_DATA_TYPES:
+                return param_value
+            else:
+                try:
+                    return json.loads(param_value)
+                except JSONDecodeError as e:
+                    logging.error(f"{e}")
+
+        if type in OpenAPIKeyWord.OBJECT:
             try:
                 return json.loads(param_value)
             except JSONDecodeError as e:


### PR DESCRIPTION
### Problem
Array is not considered as serializable object
Cli tries to work with individual array items, but when items are not simple(integer, string, etc.) then parsing is getting broken. 

```
alcli aetag crud_global_tagset_keys_by_path --path tuning/Authentication/UserLoginFailures/AttackerWhitelist --crud_list '[{"operation": "read", "key":"AttackerCIDRWhitelist"}]'

'[{"operation": "read", "key":"AttackerCIDRWhitelist"}]' is not valid under any of the given schemas. Schema: {"anyOf": [
...
```

### Resolution
Do not itemize arrays on the argparse level(nargs=+)
Serialize array body to json
