### PR TITLE
Output response if not JSON

### DIFF
--- a/alcli/alertlogic_cli.py
+++ b/alcli/alertlogic_cli.py
@@ -200,7 +200,7 @@ class ServiceOperation(object):
             try:
                 self._print_result(res.json(), parsed_globals.query)
             except json.decoder.JSONDecodeError:
-                print(f'HTTP Status Code: {res.status_code}')
+                print(f'HTTP Status Code: {res.status_code}\n{res.text}')
 
     def get_service_api(self, service_name):
         return Session.get_service_api(service_name=service_name)


### PR DESCRIPTION
### Problem

HTTP responses are not output if they are not JSON

```
$ alcli deployments create_deployment --account_id 12345678 --mode automatic --name "test"  --credentials '[{"id": "REDACTED", "purpose": "discover"}]' --platform '{"type":"aws","id":"REDACTED","monitor":{"enabled":true,"ct_install_region":"us-east-1"}}' --scope '{"include":[{"type":"region","key":"/aws/us-east-1"}]}'
HTTP Status Code: 400
```

### Solution

Output them.

```
alcli  deployments create_deployment --account_id 12345678 --mode automatic --name "test"  --credentials '[{"id": "REDACTED", "purpose": "discover"}]' --platform '{"type":"aws","id":"REDACTED","monitor":{"enabled":true,"ct_install_region":"us-east-1"}}' --scope '{"include":[{"type":"region","key":"/aws/us-east-1"}]}'
HTTP Status Code: 400
Invalid JSON. Path: credentials..id.
```