### PR TITLE
Fix unnecessary calls to less

### DIFF
--- a/alcli/alertlogic_cli.py
+++ b/alcli/alertlogic_cli.py
@@ -11,6 +11,7 @@ import logging
 import argparse
 import re
 import pydoc
+import shutil 
 
 from urllib.parse import urlparse
 from collections import OrderedDict
@@ -68,8 +69,9 @@ def cli_pager(text):
 def get_cli_pager():
     if sys.platform == 'win32':
         return lambda text: pydoc.pipepager(text, 'more /C')
-    if hasattr(os, 'system') and os.system('(less) 2>/dev/null') == 0:
+    if shutil.which('less') is not None:
         return lambda text: pydoc.pipepager(text, 'less -R')
+    return lambda text: print(text)
 
 class AlertLogicCLI(object):
     def __init__(self):

--- a/alcli/clihelp.py
+++ b/alcli/clihelp.py
@@ -6,6 +6,7 @@ import os
 import json
 import textwrap
 import itertools
+import shutil
 from almdrlib.session import Session
 from almdrlib.region import Region
 from almdrlib.region import Residency
@@ -42,11 +43,7 @@ def get_param_type(spec):
                 f'Unsupported parameter type. {json.dumps(spec, indent=2)}')
 
 class FormatHelp:
-    if sys.platform == 'win32':
-        BOLD = ''
-        UNDERLINE = ''
-        END = ''
-    elif hasattr(os, 'system') and os.system('(less) 2>/dev/null') == 0:
+    if shutil.which('less') is not None:
         BOLD = '\033[1m'
         UNDERLINE = '\033[4m'
         END = '\033[0m'


### PR DESCRIPTION
There was an unnecessarily complex call to `less` to check if it is available on the path.  This actually
invoked `less` without a filename and without a piped input.  Some versions of `less` (e.g. the default on
OS X) allow this, but others (e.g. the version installed by Homebrew) don't.

The call to `less` happened in a class initialization, so every call to `alcli` called `less`, which
printed an error on stdout that said `Missing filename ("less --help" for help)`.  This broke piping to jq.

The fix is to use `shutil.which` to find the path to `less`, if it exists.

Additionally, this fixes a potential bug where the system isn't `"win32"` and `less` isn't on the path.
Previously it would crash trying to invoke `None(help_text)` when printing help text. Now it emits the text
directly.