### PR TITLE
Format JSON decoding errors better.  Use logger to ensure it gets outputted

### DIFF
--- a/alcli/alertlogic_cli.py
+++ b/alcli/alertlogic_cli.py
@@ -284,7 +284,14 @@ class ServiceOperation(object):
                 try:
                     return json.loads(param_value)
                 except JSONDecodeError as e:
-                    logging.error(f"{e}")
+                    import textwrap
+                    bad_input_lines = param_value.split('\n')
+                    bad_input_lines.insert(e.lineno, ' ' * (e.colno - 1) + "^ ERROR")
+                    explainer = '\n'.join(bad_input_lines)
+                    explainer = textwrap.indent(explainer, '    ')
+                    logger.error(f"Unable to parse input as JSON.  "
+                                 f"Line {e.lineno}, column {e.colno}: {e.msg}\n"
+                                 f"Input:\n{explainer}\nFalling back to using the input as a string.")
 
         if parameter_type in OpenAPIKeyWord.OBJECT:
             try:


### PR DESCRIPTION
Output JSON decoding errors better.  This adds a pointer to the location of the error (according to Python's JSON parser).  This **does not** override the fall-through case though -- if you pass bad JSON, it's treated as a string instead of parsed JSON.