### PR TITLE
support body argument and response in other formats than json

### DIFF
--- a/alcli/alertlogic_cli.py
+++ b/alcli/alertlogic_cli.py
@@ -199,7 +199,9 @@ class ServiceOperation(object):
             # Remove optional arguments that haven't been supplied
             op_args = {k:self._encode(operation, k, v) for (k,v) in kwargs.items() if v is not None}
             res = operation(**op_args)
-            if res.headers.get('content-type') == 'text/plain':
+            content_type = res.headers.get('content-type')
+            json_content_types = ['application/json', 'alertlogic/json']
+            if content_type and content_type not in json_content_types:
                 print(res.text)
             else:
                 try:
@@ -307,7 +309,10 @@ class ServiceOperation(object):
                     (m.groupdict()['key'], m.groupdict()['value'])
                     for m in regex.finditer(param_value)
                 )
-                return result
+                if result:
+                    return result
+                else:
+                    return param_value
 
         # TODO Raise an exception if we can't build a dictionary from the provided input
         return param_value


### PR DESCRIPTION
### Problem
alcli is trying to parse data as json data type

### Solution
fallback to original string value if json cannot be parsed

### Related
https://github.com/alertlogic/alertlogic-sdk-python/pull/111
