### PR TITLE
Point to new location of windows signtool

### DIFF
--- a/scripts/windows/build_inno_setup.ps1
+++ b/scripts/windows/build_inno_setup.ps1
@@ -5,6 +5,6 @@ New-Item -Path "HKCU:\Software\Jordan Russell" -Name "Inno Setup";
 New-Item -Path "HKCU:\Software\Jordan Russell\Inno Setup" -Name "SignTools";
 $registryPath = "HKCU:\Software\Jordan Russell\Inno Setup\SignTools";
 $name = "SignTool0";
-$value = "signtool=C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe sign /a /sm /s My /n `"Alert Logic`" `$f";
+$value = "signtool=C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x64/signtool.exe sign /a /sm /s My /n `"Alert Logic`" /fd certHash `$f";
 New-ItemProperty -Path $registryPath -Name $name -Value $value;
 c:\innosetup\iscc.exe /dMyAppVersion=$version /Odist scripts/windows/alcli_windows_install.iss


### PR DESCRIPTION
Point to latest SDK version of signtool defined [here](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md).