### PR TITLE
Add runs-on to scheduled action

### DIFF
--- a/.github/workflows/scheduled_tests.yml
+++ b/.github/workflows/scheduled_tests.yml
@@ -8,12 +8,15 @@ on:
 
 jobs:
   test_code:
+    runs-on: ubuntu-latest
     steps:
         - uses: ./.github/workflows/run_tests
   test_python_build:
+    runs-on: ubuntu-latest
     steps:
         - uses: ./.github/workflows/build_python
   test_windows_build:
+    runs-on: windows-latest
     steps:
         - uses: ./.github/workflows/build_windows
   alert:


### PR DESCRIPTION
Even though the jobs just called other jobs which have 'runs-on' set it turns out they also need 'runs-on'