### PR TITLE
Fix local workflows and pagerduty alert + add ability to run manually

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -2,6 +2,7 @@ name: Build python distribution
 on:
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -2,6 +2,7 @@ name: Build and sign windows artifacts
 on:
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-        - uses: ./.github/workflows/run_tests
+    uses: ./.github/workflows/run_tests.yml
   release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -5,13 +5,12 @@ on:
       - created
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-        - uses: ./.github/workflows/run_tests
+    uses: ./.github/workflows/run_tests.yml
   release:
     runs-on: windows-latest
     steps:
       - uses: ./.github/workflows/build_windows
+        secrets: inherit
       - name: Upload Release executable setup
         id: upload-exe-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,6 +3,7 @@ name: Run Tests
 on:
   workflow_call:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/scheduled_tests.yml
+++ b/.github/workflows/scheduled_tests.yml
@@ -3,27 +3,24 @@ name: Run Scheduled Tests
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # Run every day at 12:00 UTC
-    - cron:  '00 12 * * *'  
+    # Run every day at 16:00 UTC
+    - cron:  '00 16 * * *'
+  workflow_dispatch:
 
 jobs:
   test_code:
-    runs-on: ubuntu-latest
-    steps:
-        - uses: ./.github/workflows/run_tests
+    uses: ./.github/workflows/run_tests.yml
   test_python_build:
-    runs-on: ubuntu-latest
-    steps:
-        - uses: ./.github/workflows/build_python
+    uses: ./.github/workflows/build_python.yml
   test_windows_build:
-    runs-on: windows-latest
-    steps:
-        - uses: ./.github/workflows/build_windows
+    uses: ./.github/workflows/build_windows.yml
+    secrets: inherit
   alert:
     runs-on: ubuntu-latest
+    needs: [test_code, test_python_build, test_windows_build]
     if: failure()
     steps:
-      - name: Run Tests
+      - name: Alert Pager Duty of Failure
         run: |
           curl --request POST \
                --url https://events.pagerduty.com/v2/enqueue \
@@ -35,7 +32,6 @@ jobs:
                       "source": "https://github.com/alertlogic/alcli"
                   },
                   "routing_key": "551f474142b44702c00f0861398f614a",
-                  "dedup_key": "alcli_failure",
                   "event_action": "trigger",
                   "links": [
                       {


### PR DESCRIPTION
Previously we were referencing the other workflows as if they were actions which is incorrect. Also, a pager duty incident won't be created if no-one is on call, which is the case for the non-critical policy at 12 UTC so instead the tests now run at 16 UTC.

This PR also adds the ability to run the testing workflows manually which really helps debugging - proof of it working https://github.com/alertlogic/alcli/actions/runs/5739546841/job/15555376885